### PR TITLE
feat: Add first modifications to uncaught/unseen checkboxes

### DIFF
--- a/common/src/main/kotlin/com/metacontent/cobblenav/client/gui/screen/pokefinder/PokefinderScreen.kt
+++ b/common/src/main/kotlin/com/metacontent/cobblenav/client/gui/screen/pokefinder/PokefinderScreen.kt
@@ -19,7 +19,7 @@ import net.minecraft.util.FastColor
 class PokefinderScreen : Screen(Component.literal("Pokefinder")) {
     companion object {
         const val WIDTH: Int = 288
-        const val HEIGHT: Int = 192
+        const val HEIGHT: Int = 192 # TODO - Calculate new HEIGHT with the 2 new CheckBoxes
         const val LOGO_SIZE: Int = 64
         const val BORDER: Int = 5
         const val SETTING_WIDTH: Int = 160
@@ -47,6 +47,8 @@ class PokefinderScreen : Screen(Component.literal("Pokefinder")) {
     private lateinit var strictAspectCheckBox: CheckBox
     private lateinit var strictLabelCheckBox: CheckBox
     private lateinit var shinyOnlyCheckBox: CheckBox
+    private lateinit var uncaughtOnlyCheckBox: CheckBox
+    private lateinit var unseenOnlyCheckBox: CheckBox
     private val settings = CobblenavClient.pokefinderSettings
 
     override fun init() {
@@ -134,6 +136,28 @@ class PokefinderScreen : Screen(Component.literal("Pokefinder")) {
             default = settings?.shinyOnly ?: false,
             afterClick = { button -> settings?.let { it.shinyOnly = (button as CheckBox).checked } }
         ).also { addWidget(it) }
+        uncaughtOnlyCheckBox = CheckBox(
+            pX = screenX + BORDER + X_OFFSET,
+            pY = screenY + BORDER + 3 * Y_FIELD_OFFSET + 3 * FIELD_HEIGHT + 3 * Y_CHECK_BOX_OFFSET + 3 * CHECK_BOX_HEIGHT,
+            pWidth = SETTING_WIDTH,
+            pHeight = CHECK_BOX_HEIGHT,
+            textOffset = 6,
+            text = Component.translatable("gui.cobblenav.uncaught_only"),
+            shadow = true,
+            default = settings?.uncaughtOnly ?: false,
+            afterClick = { button -> settings?.let { it.uncaughtOnly = (button as CheckBox).checked } }
+        ).also { addWidget(it) }
+        unseenOnlyCheckBox = CheckBox(
+            pX = screenX + BORDER + X_OFFSET,
+            pY = screenY + BORDER + 3 * Y_FIELD_OFFSET + 3 * FIELD_HEIGHT + 3 * Y_CHECK_BOX_OFFSET + 4 * CHECK_BOX_HEIGHT,
+            pWidth = SETTING_WIDTH,
+            pHeight = CHECK_BOX_HEIGHT,
+            textOffset = 6,
+            text = Component.translatable("gui.cobblenav.unseen_only"),
+            shadow = true,
+            default = settings?.unseenOnly ?: false,
+            afterClick = { button -> settings?.let { it.unseenOnly = (button as CheckBox).checked } }
+        ).also { addWidget(it) }
     }
 
     override fun render(guiGraphics: GuiGraphics, mouseX: Int, mouseY: Int, delta: Float) {
@@ -175,6 +199,8 @@ class PokefinderScreen : Screen(Component.literal("Pokefinder")) {
         strictAspectCheckBox.render(guiGraphics, mouseX, mouseY, delta)
         strictLabelCheckBox.render(guiGraphics, mouseX, mouseY, delta)
         shinyOnlyCheckBox.render(guiGraphics, mouseX, mouseY, delta)
+        uncaughtOnlyCheckBox.render(guiGraphics, mouseX, mouseY, delta)
+        unseenOnlyCheckBox.render(guiGraphics, mouseX, mouseY, delta)
 
         blitk(
             matrixStack = poseStack,

--- a/common/src/main/kotlin/com/metacontent/cobblenav/client/settings/PokefinderSettings.kt
+++ b/common/src/main/kotlin/com/metacontent/cobblenav/client/settings/PokefinderSettings.kt
@@ -40,6 +40,16 @@ class PokefinderSettings : Settings<PokefinderSettings>() {
             changed = true
             field = value
         }
+    var uncaughtOnly = false
+        set(value) {
+            changed = true
+            field = value
+        }
+    var unseenOnly = false
+        set(value) {
+            changed = true
+            field = value
+        }
 
     fun check(pokemon: Pokemon): Boolean {
         return if (species.isNotEmpty() && !species.map(String::lowercase).contains(pokemon.species.name.lowercase())) {
@@ -58,6 +68,12 @@ class PokefinderSettings : Settings<PokefinderSettings>() {
             false
         }
         else if (shinyOnly && !pokemon.shiny) {
+            false
+        }
+        else if (uncaughtOnly && pokemon.caught) { # TODO - Find property for caught (or calculate from pokedex list)
+            false
+        }
+        else if (unseenOnly && pokemon.seen) { # TODO - Find property for seen (or calculate from pokedex list)
             false
         }
         else {

--- a/common/src/main/resources/assets/cobblenav/lang/en_us.json
+++ b/common/src/main/resources/assets/cobblenav/lang/en_us.json
@@ -58,6 +58,8 @@
   "gui.cobblenav.strict_aspect_check": "Strict Aspect Check",
   "gui.cobblenav.strict_label_check": "Strict Label Check",
   "gui.cobblenav.shiny_only": "Shiny Only",
+  "gui.cobblenav.uncaught_only": "Uncaught Only",
+  "gui.cobblenav.unseen_only": "Unseen Only",
   "gui.cobblenav.empty_spawns_message": "There doesn't seem to be anyone living here",
   "gui.cobblenav.spawn_data.unknown_pokemon": "???",
   "gui.cobblenav.spawn_data.spawn_chance": "Chance: %s%%",


### PR DESCRIPTION
This Pull Request might have to be merged into another branch (not main) because it is unfinished.

Work to do before fully finishing the work :
* Resize PokeFinder window to hold the 2 new checkboxes (might have to rework the background asset)
(com.metacontent.cobblenav.client.gui.screen.pokefinder.PokefinderScreen)
* Finish the functionality of how to filter found pokemons (seen/captured) maybe from Pokedex of the current client ?
(com.metacontent.cobblenav.client.settings.PokefinderSettings)
