### PR TITLE
feat(pokefinder): add species selector and quick clear button

### DIFF
--- a/common/src/main/kotlin/com/metacontent/cobblenav/client/gui/widget/button/TextButton.kt
+++ b/common/src/main/kotlin/com/metacontent/cobblenav/client/gui/widget/button/TextButton.kt
@@ -23,7 +23,7 @@ class TextButton(
 ) : PokenavButton(pX, pY, pWidth, pHeight, text, disabled, action) {
     override fun renderWidget(guiGraphics: GuiGraphics, i: Int, j: Int, f: Float) {
 
-        var argb = 1f
+        var argb = 0.9f
         if (disabled) {
             argb -= 0.4f
         }


### PR DESCRIPTION
- Added SpeciesSelector widget that displays nearby Pokemon species
- Implemented SpeciesSelectorEntry for clickable species items
- Added clear button (×) to quickly reset species filter
- Species selector populates from entities within 200-block radius
- Clicking species automatically adds it to the filter
- Adjusted TextButton opacity from 1.0f to 0.9f for better appearance