### PR TITLE
fix(pokefinder): use localized pokemon names for search

### DIFF
--- a/common/src/main/kotlin/com/metacontent/cobblenav/client/settings/PokefinderSettings.kt
+++ b/common/src/main/kotlin/com/metacontent/cobblenav/client/settings/PokefinderSettings.kt
@@ -42,10 +42,8 @@ class PokefinderSettings : Settings<PokefinderSettings>() {
         }
 
     fun check(pokemon: Pokemon): Boolean {
-        return if (species.isNotEmpty() && !species.map(String::lowercase).contains(pokemon.species.name.lowercase())) {
-            false
-        }
-        else if (strictAspectCheck && !pokemon.aspects.containsAll(aspects.map(String::lowercase))) {
+        val lowercaseSpecies = species.map(String::lowercase)
+        return if (species.isNotEmpty() && !lowercaseSpecies.contains(pokemon.species.name.lowercase()) && !lowercaseSpecies.contains(pokemon.species.translatedName.string.lowercase())) {        else if (strictAspectCheck && !pokemon.aspects.containsAll(aspects.map(String::lowercase))) {
             false
         }
         else if (!strictAspectCheck && aspects.isNotEmpty() && !aspects.any { pokemon.aspects.contains(it.lowercase()) }) {


### PR DESCRIPTION
Fixes #66 

I think there's a bigger translation work for UIs to think about if you are interested, but this at least fixes the feature to not require a browser to translate names while playing